### PR TITLE
Documentation clarification and startActivity DSL fix

### DIFF
--- a/SwissKnife/src/main/groovy/com/arasthel/swissknife/dsl/AndroidContextDSL.groovy
+++ b/SwissKnife/src/main/groovy/com/arasthel/swissknife/dsl/AndroidContextDSL.groovy
@@ -56,12 +56,14 @@ public class AndroidContextDSL {
 
     static void startActivity(Context self,
                               Class<? extends Activity> activity,
-                              @DelegatesTo(value=Intent, strategy = Closure.DELEGATE_FIRST) Closure intentSpec) {
+                              @DelegatesTo(value=Intent, strategy = Closure.DELEGATE_FIRST) Closure intentSpec = null) {
         def intent = new Intent(self, activity)
-        def clone = (Closure) intentSpec.clone()
-        clone.resolveStrategy = Closure.DELEGATE_FIRST
-        clone.delegate = intent
-        clone()
+        if(intentSpec != null){
+            def clone = (Closure) intentSpec.clone()
+            clone.resolveStrategy = Closure.DELEGATE_FIRST
+            clone.delegate = intent
+            clone()
+        }
         self.startActivity(intent)
     }
 

--- a/docs/annotations.adoc
+++ b/docs/annotations.adoc
@@ -20,7 +20,7 @@ public void onClick(View v)
 ----
 @OnClick(R.id.button)
 public void onClick() {
-    Toast.makeText(this, "Button clicked", Toast.LENGTH_SHORT).show();
+    Toast.makeText(this, "Button clicked", Toast.LENGTH_SHORT).show()
 }
 ----
 
@@ -42,8 +42,8 @@ Notice it must return a boolean
 ----
 @OnLongClick(R.id.button)
 public boolean onLongClick() {
-    Toast.makeText(this, "Button long clicked", Toast.LENGTH_SHORT).show();
-    return true;
+    Toast.makeText(this, "Button long clicked", Toast.LENGTH_SHORT).show()
+    return true
 }
 ----
 
@@ -70,7 +70,7 @@ public void onItemClick(int position, AdapterView adapterView, View clickedView)
 ----
 @OnItemClick(R.id.list)
 public void onItemClick(int position) {
-    Toast.makeText(this, "Item $position clicked", Toast.LENGTH_SHORT).show();
+    Toast.makeText(this, "Item $position clicked", Toast.LENGTH_SHORT).show()
 }
 ----
 
@@ -97,7 +97,7 @@ Notice it must return a boolean
 ----
 @OnItemLongClick(R.id.list)
 public void onItemLongClick(int position) {
-    Toast.makeText(this, "Item $position long-clicked", Toast.LENGTH_SHORT).show();
+    Toast.makeText(this, "Item $position long-clicked", Toast.LENGTH_SHORT).show()
 }
 ----
 
@@ -139,7 +139,7 @@ public void onNothingSelected(AdapterView adapterView)
 ----
 @OnItemSelected(value=R.id.list, method=OnItemSelected.Method.ITEM_SELECTED)
 public void onItemSelected(int position) {
-    Toast.makeText(this, "Item $position selected", Toast.LENGTH_SHORT).show();
+    Toast.makeText(this, "Item $position selected", Toast.LENGTH_SHORT).show()
 }
 ----
 
@@ -163,8 +163,8 @@ public boolean onChecked(CompoundButton button, boolean checked)
 ----
 @OnChecked(R.id.radio_button)
 public public boolean onChecked(CompoundButton button, boolean checked) {
-    Toast.makeText(this, "Button checked: $checked", Toast.LENGTH_SHORT).show();
-    return false;
+    Toast.makeText(this, "Button checked: $checked", Toast.LENGTH_SHORT).show()
+    return false
 }
 ----
 
@@ -188,7 +188,7 @@ public void onFocusChanged(View v, boolean hasFocus)
 ----
 @OnFocusChanged(R.id.my_view)
 public void onFocusChanged(boolean hasFocus) {
-    Toast.makeText(this, "View has focus: $hasFocus", Toast.LENGTH_SHORT).show();
+    Toast.makeText(this, "View has focus: $hasFocus", Toast.LENGTH_SHORT).show()
 }
 ----
 
@@ -212,8 +212,8 @@ public boolean onClick(View v, MotionEvent event)
 ----
 @OnTouch(R.id.button)
 public boolean onTouch(MotionEvent event) {
-    Toast.makeText(this, "Button touched, action: $event.action", Toast.LENGTH_SHORT).show();
-    return false;
+    Toast.makeText(this, "Button touched, action: $event.action", Toast.LENGTH_SHORT).show()
+    return false
 }
 ----
 
@@ -256,7 +256,7 @@ public void onPageScrollStateChanged(int state)
 ----
 @OnPageChanged(value=R.id.list, method=OnPageChanged.Method.PAGE_SELECTED)
 public void onPageSelected(int position) {
-    Toast.makeText(this, "Current page: $position", Toast.LENGTH_SHORT).show();
+    Toast.makeText(this, "Current page: $position", Toast.LENGTH_SHORT).show()
 }
 ----
 
@@ -316,7 +316,7 @@ public void afterTextChanged(Editable editable)
 ----
 @OnTextChanged(value=R.id.edit_text, method=OnTextChanged.Method.ON_TEXT_CHANGED)
 public void onTextChanged(CharSequence sequence) {
-    Toast.makeText(this, "Sentence written: $sequence", Toast.LENGTH_SHORT).show();
+    Toast.makeText(this, "Sentence written: $sequence", Toast.LENGTH_SHORT).show()
 }
 ----
 
@@ -340,8 +340,8 @@ public boolean onEditorAction(TextView textView, KeyEvent event)
 ----
 @OnEditorAction(R.id.edit_text)
 public boolean onEditorAction(KeyEvent event) {
-    Toast.makeText(this, "Editor action received", Toast.LENGTH_SHORT).show();
-    return false;
+    Toast.makeText(this, "Editor action received", Toast.LENGTH_SHORT).show()
+    return false
 }
 ----
 
@@ -421,7 +421,7 @@ Make sure you check the sample for more examples.
 [source, groovy]
 ----
 @SaveInstance
-TextView myTextView;
+TextView myTextView
 
 @Override
 public void onCreate(Bundle savedInstanceState){

--- a/docs/intro.adoc
+++ b/docs/intro.adoc
@@ -27,16 +27,16 @@ only annotation parameter, the *"value="* part can be ignored.
 include::{skSampleSrc}/com/dexafree/sample/MainActivity.groovy[tags=injectViewWithId,indent=0]
 
 @InjectView(value=R.id.button)
-Button myButton;
+Button myButton
 
 // To inject several views, the annotation is @InjectViews, in plural
 @InjectViews([R.id.view_1, R.id.view_2])
-List<View> myViews;
+List<View> myViews
 
 // This case here is special. If the name of the field is the same as the id,
 // the @InjectView annotation doesn't need any parameters
 @InjectView()
-Button button_1;
+Button button_1
 ----
 
 Also, you can have several listener injection methods. When the listener is
@@ -61,31 +61,44 @@ will need to tell your class to use SwissKnife. You can do it like this:
 [source, groovy]
 ----
 // Inject an Activity or a View in which "findViewById()" method is accesible
-SwissKnife.inject(Object objectInjected);
+SwissKnife.inject(Object objectInjected)
 
 // If you are using a Fragment or want to inject a View's children into any object, you use this
-SwissKnife.inject(Object objectInjected, View viewToInject);
+SwissKnife.inject(Object objectInjected, View viewToInject)
 ----
 
 For example, in an Activity, you would do it like this:
 
 [source, groovy]
 ----
-SwissKnife.inject(this);
+SwissKnife.inject(this)
 ----
 
 And in a Fragment, it would be:
 
 [source, groovy]
 ----
-SwissKnife.inject(this, getView());
+SwissKnife.inject(this, getView())
 ----
 
-You can also  inject views and listeners on other objects, like a Controller or a Presenter like this:
+But be careful! If you do it on the onCreateView method, you should pass the inflated View, as `getView()` would return null
 
 [source, groovy]
 ----
-SwissKnife.inject(controller, view);
+@Override
+public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+
+    View v = inflater.inflate(R.layout.left, container, false)
+    SwissKnife.inject(this, v)
+    return v
+}
+----
+
+You can also inject views and listeners on other objects, like a Controller or a Presenter like this:
+
+[source, groovy]
+----
+SwissKnife.inject(controller, view)
 ----
 
 This means that injection can be used on any class and is done on runtime, so


### PR DESCRIPTION
* Adds a clarification for the `SwissKnife.inject(this, getView())` in Fragments
* Fixes a bug that would crash if `startActivity(Class)` was called with a null Closure